### PR TITLE
Remove periods from td elements for personae

### DIFF
--- a/src/epub/text/the-dance-of-death.xhtml
+++ b/src/epub/text/the-dance-of-death.xhtml
@@ -20,7 +20,7 @@
 			<table>
 				<tbody>
 					<tr>
-						<td epub:type="z3998:persona">Death.</td>
+						<td epub:type="z3998:persona">Death</td>
 						<td>
 							<p>At night, in winter, when the snowflakes fall slowly from heaven like great white tears, I raise my voice; its resonance thrills the cypress trees and makes them bud anew.</p>
 							<p>I pause an instant in my swift course over earth; throw myself down among cold tombs; and, while dark-plumaged birds rise suddenly in terror from my side, while the dead slumber peacefully, while cypress branches droop low o’er my head, while all around me weeps or lies in deep repose, my burning eyes rest on the great white clouds, gigantic winding-sheets, unrolling their slow length across the face of heaven.</p>
@@ -52,20 +52,20 @@
 						</td>
 					</tr>
 					<tr>
-						<td epub:type="z3998:persona">Satan.</td>
+						<td epub:type="z3998:persona">Satan</td>
 						<td>
 							<p>Dost thou complain⁠—thou, the most fortunate creature under heaven? The only, splendid, great, unchangeable, eternal one⁠—like God, who is the only Being that equals thee! Dost thou repine, who some day in thy turn shalt disappear forever, after thou hast crushed the universe beneath thy horse’s feet?</p>
 							<p>When God’s work of creating has ceased; when the heavens have disappeared and the stars are quenched; when spirits rise from their retreats and wander in the depths with sighs and groans; then, what unpicturable delight for thee! Then shalt thou sit on the eternal thrones of heaven and of hell⁠—shalt overthrow the planets, stars, and worlds⁠—shalt loose thy steed in fields of emeralds and diamonds⁠—shalt make his litter of the wings torn from the angels⁠—shalt cover him with the robe of righteousness! Thy saddle shall be broidered with the stars of the empyrean⁠—and then thou wilt destroy it! After thou hast annihilated everything⁠—when naught remains but empty space⁠—thy coffin shattered and thine arrows broken, then make thyself a crown of stone from heaven’s highest mount, and cast thyself into the abyss of oblivion. Thy fall may last a million aeons, but thou shalt die at last. Because the world must end; all, all must die⁠—except Satan! Immortal more than God! I live to bring chaos into other worlds!</p>
 						</td>
 					</tr>
 					<tr>
-						<td epub:type="z3998:persona">Death.</td>
+						<td epub:type="z3998:persona">Death</td>
 						<td>
 							<p>But thou hast not, as I, this vista of eternal nothingness before thee; thou dost not suffer with this deathlike cold, as I.</p>
 						</td>
 					</tr>
 					<tr>
-						<td epub:type="z3998:persona">Satan.</td>
+						<td epub:type="z3998:persona">Satan</td>
 						<td>
 							<p>Nay, but I quiver under fierce and unrelaxing hearts of molten lava, which burn the doomed and which e’en I cannot escape.</p>
 							<p>For thou, at least, hast only to destroy. But I bring birth and I give life. I direct empires and govern the affairs of States and of hearts.</p>
@@ -84,7 +84,7 @@
 						</td>
 					</tr>
 					<tr>
-						<td epub:type="z3998:persona">Nero.</td>
+						<td epub:type="z3998:persona">Nero</td>
 						<td>
 							<p>Quick! Quick! And faster still, until your feet dash fire from the flinty stones and your nostrils fleck your breasts with foam. What! do not the wheels smoke yet? Hear ye the fanfares, whose sound reached even to Ostia; the clapping of the hands, the cries of joy? See how the populace shower saffron on my head! See how my pathway is already damp with sprayed perfume! My chariot whirls on; the pace is swifter than the wind as I shake the golden reins! Faster and faster! The dust clouds rise; my mantle floats upon the breeze, which in my ears sings “Triumph! triumph!” Faster and faster! Hearken to the shouts of joy, list to the stamping feet and the plaudits of the multitude. Jupiter himself looks down on us from heaven. Faster! yea, faster still!</p>
 							<hr/>
@@ -92,7 +92,7 @@
 						</td>
 					</tr>
 					<tr>
-						<td epub:type="z3998:persona">Nero.</td>
+						<td epub:type="z3998:persona">Nero</td>
 						<td>
 							<p>Now, let six hundred of my women dance the Grecian Dances silently before me, the while I lave myself with roses in a bath of porphyry. Then let them circle me, with interlacing arms, that I may see on all sides alabaster forms in graceful evolution, swaying like tall reeds bending over an amorous pool.</p>
 							<p>And I will give the empire and the sea, the Senate, the Olympus, the Capitol, to her who shall embrace me the most ardently; to her whose heart shall throb beneath my own; to her who shall enmesh me in her flowing hair, smile on me sweetest, and enfold me in the warmest clasp; to her who soothing me with songs of love shall waken me to joy and heights of rapture! Rome shall be still this night; no barque shall cleave the waters of the Tiber, since ’tis my wish to see the mirrored moon on its untroubled face and hear the voice of woman floating over it. Let perfumed breezes pass through all my draperies! Ah, I would die, voluptuously intoxicated.</p>
@@ -104,49 +104,49 @@
 						</td>
 					</tr>
 					<tr>
-						<td epub:type="z3998:persona">Death.</td>
+						<td epub:type="z3998:persona">Death</td>
 						<td>
 							<p>Instantly!</p>
 						</td>
 					</tr>
 					<tr>
-						<td epub:type="z3998:persona">Nero.</td>
+						<td epub:type="z3998:persona">Nero</td>
 						<td>
 							<p>Must I give up my days of feasting and delight, my spectacles, my triumphs, my chariots and the applause of multitudes?</p>
 						</td>
 					</tr>
 					<tr>
-						<td epub:type="z3998:persona">Death.</td>
+						<td epub:type="z3998:persona">Death</td>
 						<td>
 							<p>All! All!</p>
 						</td>
 					</tr>
 					<tr>
-						<td epub:type="z3998:persona">Satan.</td>
+						<td epub:type="z3998:persona">Satan</td>
 						<td>
 							<p>Haste, Master of the World! One comes⁠—One who will put thee to the sword. An emperor knows how to die!</p>
 						</td>
 					</tr>
 					<tr>
-						<td epub:type="z3998:persona">Nero.</td>
+						<td epub:type="z3998:persona">Nero</td>
 						<td>
 							<p>Die! I have scarce begun to live! Oh, what great deeds I should accomplish⁠—deeds that should make Olympus tremble! I would fill up the bed of hoary ocean and speed across it in a triumphal car. I would still live⁠—would see the sun once more, the Tiber, the Campagna, the Circus on the golden sands. Ah! let me live!</p>
 						</td>
 					</tr>
 					<tr>
-						<td epub:type="z3998:persona">Death.</td>
+						<td epub:type="z3998:persona">Death</td>
 						<td>
 							<p>I will give thee a mantle for the tomb, and an eternal bed that shall be softer and more peaceful than the Imperial couch.</p>
 						</td>
 					</tr>
 					<tr>
-						<td epub:type="z3998:persona">Nero.</td>
+						<td epub:type="z3998:persona">Nero</td>
 						<td>
 							<p>Yet, I am loth to die.</p>
 						</td>
 					</tr>
 					<tr>
-						<td epub:type="z3998:persona">Death.</td>
+						<td epub:type="z3998:persona">Death</td>
 						<td>
 							<p>Die, then!</p>
 							<hr/>


### PR DESCRIPTION
The drama how-to specifies that personae in their own `td` don't end with periods, but I can't see it in the manual; maybe worth mentioning in/below [7.6.5.1](https://standardebooks.org/manual/1.8.1/single-page#7.6.5.1)?